### PR TITLE
(feat) adding ejs views and react component views from server-side

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "mocha": "^3.0.2"
+    "ejs": "^2.5.1",
+    "mocha": "^3.0.2",
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1"
   }
 }

--- a/ui-server/react/index.js
+++ b/ui-server/react/index.js
@@ -1,7 +1,11 @@
 var React = require("react")
-var IndexComponent = React.createClass({
-    render:function(){
-        return React.createElement('h1', null, 'Hello Doge');
-    }
-});
-module.exports = IndexComponent;
+module.exports = class Index extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    console.log('props', this.props)
+    return React.createElement('h1', null, 'Hello React Doge');
+  }
+}

--- a/ui-server/react/index.js
+++ b/ui-server/react/index.js
@@ -1,0 +1,7 @@
+var React = require("react")
+var IndexComponent = React.createClass({
+    render:function(){
+        return React.createElement('h1', null, 'Hello Doge');
+    }
+});
+module.exports = IndexComponent;

--- a/ui-server/ui-routes.js
+++ b/ui-server/ui-routes.js
@@ -48,7 +48,7 @@ module.exports = function(app) {
 
   app.get('*', function(req, res) {
     // converts react/index component to a react component
-    var ReactComponent = React.createElement(indexComponent);
+    var ReactComponent = React.createElement(indexComponent, Object.assign({}, this.props, { more: 'values' }));
     // renders the component to an html string
     staticMarkup = ReactDOMServer.renderToString(ReactComponent);
     // passes the html string into the view as indexComponentMarkup

--- a/ui-server/ui-routes.js
+++ b/ui-server/ui-routes.js
@@ -2,6 +2,10 @@ var Message = require('../db/models/message');
 var path= require('path');
 var q = require('q');
 
+var React = require('react');
+var ReactDOMServer = require('react-dom/server')
+var indexComponent = require('./react/index');
+
 var findMessage = q.nbind(Message.findOne, Message);
 var createMessage = q.nbind(Message.create, Message);
 var findAllMessages = q.nbind(Message.find, Message);
@@ -43,6 +47,11 @@ module.exports = function(app) {
   });
 
   app.get('*', function(req, res) {
-    res.sendfile(path.join(__dirname, '../public/views', 'index.html'));
+    // converts react/index component to a react component
+    var ReactComponent = React.createElement(indexComponent);
+    // renders the component to an html string
+    staticMarkup = ReactDOMServer.renderToString(ReactComponent);
+    // passes the html string into the view as indexComponentMarkup
+    res.render(__dirname + '/views/index', { indexComponentMarkup: staticMarkup });
   });
 };

--- a/ui-server/ui-server.js
+++ b/ui-server/ui-server.js
@@ -5,6 +5,7 @@ var methodOverride = require('method-override');
 var app = express();
 var port = process.env.PORT || 4568;
 
+app.set('view engine', 'ejs')
 app.use(bodyParser.json());
 app.use(bodyParser.json({ type: 'application/vnd.api+json' }));
 app.use(bodyParser.urlencoded({ extended: true }));

--- a/ui-server/views/index.ejs
+++ b/ui-server/views/index.ejs
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>DogeBot 9000</title>
+</head>
+<body>
+  <%- indexComponentMarkup %>
+</body>
+</html>


### PR DESCRIPTION
- Adds the ejs, react and react-dom as dev dependencies to package.json
- Adds a react component folder that holds react-based views
- Adds a views folder that holds ejs templates
- Adds a generic index react component view to the wildcard route in ui-routes
- Has a test props passed into the react component view to confirm data passing through
