### PR TITLE
(fix) adding mongoose options to drop dupes on message schema

### DIFF
--- a/db/models/message.js
+++ b/db/models/message.js
@@ -1,6 +1,6 @@
 var db = require('../config');
 var MessageSchema = new db.Schema({
-  key: String,
+  key: { type: String, index: { unique: true, dropDups: true } },
   user: String,
   text: String,
   channel: String,


### PR DESCRIPTION
Found the solution here: http://stackoverflow.com/questions/5535610/mongoose-unique-index-not-working

Might require a resetting of the database to get the options working.

Verified working locally
